### PR TITLE
Fix bullseye install : php-gettext -> php-php-gettext

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,7 +7,7 @@ YNH_PHP_VERSION="7.3"
 
 pkg_dependencies="postgresql apt-transport-https libgd-dev"
 
-extra_php_dependencies="php${YNH_PHP_VERSION}-pgsql php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-bcmath php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-gmp php${YNH_PHP_VERSION}-gd php-gettext"
+extra_php_dependencies="php${YNH_PHP_VERSION}-pgsql php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-bcmath php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-gmp php${YNH_PHP_VERSION}-gd php-php-gettext"
 
 #=================================================
 # COMMON HELPERS


### PR DESCRIPTION
c.f. https://packages.debian.org/buster/php-gettext

>This dummy package is provided to smooth the upgrade from php-gettext to php-php-gettext and can be safely removed afterwards 