### PR TITLE
Utilisation 

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://download.noalyss.eu/noalyss-package/version-90/noalyss-9020.tar.gz
-SOURCE_SUM=0424c9c7e82bb9a3dd3402f0b5ea8259176a2dbe388a942393e68b4dbf41d59d
+SOURCE_SUM=c7b03fd0216866b85f12da84f2c913362749e000a98ce2e853de5c3c01b2ba19
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://download.noalyss.eu/derniere-version/noalyss-9011.tar.gz
+SOURCE_URL=https://download.noalyss.eu/noalyss-package/version-90/noalyss-9020.tar.gz
 SOURCE_SUM=0424c9c7e82bb9a3dd3402f0b5ea8259176a2dbe388a942393e68b4dbf41d59d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz


### PR DESCRIPTION
## Problem

`https://download.noalyss.eu/derniere-version/noalyss-9011.tar.gz` n'existe plus

## Solution

Utiliser la ressource `noalyss-package/version-XX` plutôt que `derniere-version/`
Changment de l'url actuelle pour: `https://download.noalyss.eu/noalyss-package/version-90/noalyss-9020.tar.gz`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
