### PR TITLE
Standard install fixed

### DIFF
--- a/conf/noalyss.conf
+++ b/conf/noalyss.conf
@@ -19,8 +19,15 @@ define ("LOCALE",1);
 define ("domaine","");
 define ("MULTI",1);
 define ("dbname","");
- // Uncomment to DEBUG
-define ("DEBUG",TRUE);
+
+/* 
+    * DEBUGNOALYSS let you see more information when you develop.
+    * 0 = for production
+    * 1 = display all errors
+    * 2 = display all errors + more information 
+    */
+
+define ("DEBUGNOALYSS",0);
 // Uncomment to log your input
 // define ("LOGINPUT",TRUE);
 // Uncomment if you want to activate the possibility to reinitialize
@@ -74,3 +81,8 @@ define ("DEBUG",TRUE);
 // define ('SESSION_KEY','abcde');
 // Max size is defined by default to 2MB, it could be also needed to modify PHP Ini file
 //    define ("MAX_FILE_SIZE",2097152);
+// Create your own SESSION_KEY
+// define ("SESSION_KEY","irazap492pq11");
+// 
+// Audit everything
+// define ("AUDIT_ENABLE",true);

--- a/manifest.json
+++ b/manifest.json
@@ -51,7 +51,7 @@
             {
                 "name": "is_public",
                 "type": "boolean",
-                "default": true
+                "default": false
             }
         ]
     }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -140,18 +140,12 @@ ynh_psql_dump_all_user_dbs() {
 	
 	local dbs_to_dump = ynh_psql_list_user_dbs $db_user
 	if [ -n "$dbs_to_dump" ]; then	   # Check that the list of database(s) is not empty 
-		local app_tag		
-		if [ -n "$app" ]; then
-			app_tag = "${app}-"
-		else 
-			app_tag = ""
-		fi
 		
 		local db_name
 		for $db_name in $dbs_to_dump   # Iterate through the list of database(s) to dump
 		do
 			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
-				ynh_psql_dump_db $db_name > "${app_tag}${db_name}-dump.sql" # Dump the database to a filename format of app-db_name-dump.sql, or of db_name-dump.sql if app parameter was not supplied  
+				ynh_psql_dump_db $db_name > "$app-$db_name-dump.sql" # Dump the database to a filename format of app-db_name-dump.sql, or of db_name-dump.sql if app parameter was not supplied  
 				ynh_print_info --message="Dumped database $db_name associated to role $db_user"
 			else
 				ynh_print_warn --message="Database $db_name not found"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -109,7 +109,7 @@ ynh_psql_remove_all_user_dbs() {
 	if [ -n "$dbs_to_drop" ]; then	   # Check that the list of database(s) is not empty 
 		
 		local db_name
-		for db_name in $dbs_to_drop   # Iterate through the list of database(s) to remove
+		for db_name in $dbs_to_drop   # Iterate through the list of database(s) to remove. Note: this would fail in case databases names would contain space character or characters such as "*". IFS parsing method would then be required. 
 		do
 			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
 				ynh_psql_drop_db $db_name                         # Remove the database
@@ -143,7 +143,7 @@ ynh_psql_dump_all_user_dbs() {
 	if [ -n "$dbs_to_dump" ]; then	   # Check that the list of database(s) is not empty 
 		
 		local db_name
-		for db_name in $dbs_to_dump   # Iterate through the list of database(s) to dump
+		for db_name in $dbs_to_dump   # Iterate through the list of database(s) to dump. Note: this would fail in case databases names would contain space character or characters such as "*". IFS parsing method would then be required. 
 		do
 			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
 				ynh_psql_dump_db $db_name > "$app-$db_name-dump.sql" # Dump the database to a filename format of app-db_name-dump.sql, or of db_name-dump.sql if app parameter was not supplied  

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -131,7 +131,7 @@ ynh_psql_remove_all_user_dbs() {
 ynh_psql_dump_all_user_dbs() {
     # Declare an array to define the options of this helper.
     local legacy_args=ua
-    local -A args_array=([u]=db_user= [a]=app=)) 
+    local -A args_array=([u]=db_user= [a]=app=)
     local db_user
     local app
     # Manage arguments with getopts

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -71,3 +71,143 @@ $(yunohost tools diagnosis | grep -B 100 "services:" | sed '/services:/d')"
 	# Send the email to the recipients
 	echo "$mail_message" | $mail_bin -a "Content-Type: text/plain; charset=UTF-8" -s "$mail_subject" "$recipients"
 }
+
+#### List all existing PostgreSQL databases associated with a given user
+#
+# [internal]
+#
+# usage: ynh_psql_list_user_dbs db_user
+# | arg: db_user  - the PostgreSQL role/user of which to list all owned databases
+ynh_psql_list_user_dbs() {
+	local db_user=$1
+	
+	if ynh_psql_user_exists --user=$db_user; then # Check that the db_user exists
+		local sql="COPY (SELECT datname FROM pg_database JOIN pg_authid ON pg_database.datdba = pg_authid.oid WHERE rolname = '${db_user}') TO STDOUT"
+		local dbs_list=ynh_psql_execute_as_root --sql="$sql" # Fetch database(s) associated to role $db_user
+		return dbs_list
+	else
+		ynh_print_err --message="User \'$db_user\' does not exist"
+		return ""
+	fi
+}
+
+#### Remove all existing PostgreSQL databases associated with a given user
+#
+# usage: ynh_psql_remove_all_user_dbs --db_user=db_user
+# | arg: -u, --db_user=    - the PostgreSQL role/user of which to remove all owned databases
+#
+# This can be useful to prepare the removal of a given user.
+ynh_psql_remove_all_user_dbs() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=u
+    local -A args_array=([u]=db_user=)
+    local db_user
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+	
+	local dbs_to_drop = ynh_psql_list_user_dbs $db_user
+	if [ -n "$dbs_to_drop" ]; then	   # Check that the list of database(s) is not empty 
+		local db_name
+		for $db_name in $dbs_to_drop   # Iterate through the list of database(s) to remove
+		do
+			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
+				ynh_psql_drop_db $db_name                         # Remove the database
+				ynh_print_info --message="Removed database $db_name associated to role $db_user"
+			else
+				ynh_print_warn --message="Database $db_name not found"
+			fi
+		done
+	else 
+		ynh_print_warn --message="No associated database to role $db_user was found"
+	fi
+}
+
+# Dump all existing PostgreSQL databases associated with a given user
+#
+# usage: ynh_psql_dump_all_user_dbs --db_user=db_user [--app=app]
+# | arg: -u, --db_user=    - the PostgreSQL role/user of which to remove all owned databases
+# | arg: -a, --app=     - the application id to tag the dump with
+# Requires YunoHost version 3.5.0 or higher.
+ynh_psql_dump_all_user_dbs() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=ua
+    local -A args_array=([u]=db_user= [a]=app=)) 
+    local db_user
+    local app
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    app="${app:-}"
+	
+	local dbs_to_dump = ynh_psql_list_user_dbs $db_user
+	if [ -n "$dbs_to_dump" ]; then	   # Check that the list of database(s) is not empty 
+		local app_tag		
+		if [ -n "$app" ]; then
+			app_tag = "${app}-"
+		else 
+			app_tag = ""
+		fi
+		
+		local db_name
+		for $db_name in $dbs_to_dump   # Iterate through the list of database(s) to dump
+		do
+			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
+				ynh_psql_dump_db $db_name > "${app_tag}${db_name}-dump.sql" # Dump the database to a filename format of app-db_name-dump.sql, or of db_name-dump.sql if app parameter was not supplied  
+				ynh_print_info --message="Dumped database $db_name associated to role $db_user"
+			else
+				ynh_print_warn --message="Database $db_name not found"
+			fi
+		done
+	else 
+		ynh_print_warn --message="No associated database to role $db_user was found"
+	fi
+}
+
+# Restore all dumped PostgreSQL databases for the given app
+#
+# usage: ynh_psql_restore_all_app_dbs_dumps --db_user=db_user [--db_user_pwd=db_user_pwd]
+# | arg: -u, --db_user=    		- the PostgreSQL role/user which will own the restored databases. If not existing, it will be created.
+# | arg: -p, --db_user_pwd= 	- the password associated to the PostgreSQL role/user which will own the databases. If not existing, it will be generated and saved to the app's config file.
+#	
+# SQL dump files to restore must be named according to this format "app_id-db_name-dump.sql" and be located in the app folder 
+# The filename format requirement is made so to match the files dumped with ynh_psql_dump_all_user_dbs --user=user --app=app (with both parameters specified).
+# 
+# Requires YunoHost version 2.7.13 or higher.
+ynh_psql_restore_all_app_dbs_dumps(){
+    # Declare an array to define the options of this helper.
+    local legacy_args=up
+    local -A args_array=([u]=db_user= [p]=db_user_pwd=)
+    local db_user
+    local db_user_pwd
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"	
+	
+	if [ -z "$app" ]; then
+		ynh_die --message="No global app_ID variable defined in the script"
+	fi
+
+	ynh_psql_test_if_first_run  # Make sure PSQL is installed
+	
+	local filename
+	for filename in *-dump.sql	# Loop among all files ending with "-dump.sql" in the current folder  
+	do	
+		local db_name
+		db_name="${filename#${app}-}"							# Remove "$app-" prefix from filename string to parse db_name. Will do nothing if there is no match.
+		db_name="${db_name%-dump.sql}"							# Remove "-dump.sql" suffix from filename string to parse db_name. Will do nothing if there is no match.
+		db_name=ynh_sanitize_dbid --db_name="$db_name"
+		
+		if [[ "${filename#${app}-}" = "$filename" || -z "$db_name" ]] ; then  	# Check whether app_ID is included in filename OR $db_name is empty
+			ynh_print_warn --message="File ignored: $filename. Filename not matching expected format (appID-db_name-dump.sql)"
+			continue												
+		else														
+		    db_user_pwd="${db_user_pwd:-}"
+			if [ -z "$db_user_pwd" ]; then 
+				db_user_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd) 				# Try to retrieve db_user_pwd from the app's settings. It may prove empty during the first loop, but will get populated before the second loop by ynh_psql_setup_db() below.   
+			fi
+			
+			ynh_psql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_user_pwd	# Check that the db_user exists or create it generating a random password and then create an empty database named $db_name.  
+			ynh_psql_execute_file_as_root --file="./${filename}" --database=$db_name		# Restore the dabatase from the corresponding dump file
+			
+			ynh_print_info --message="Restored database $db_name, owned by PostgreSQL user $db_user"
+		fi
+	done	
+}

--- a/scripts/backup
+++ b/scripts/backup
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source ../settings/scripts/_common.sh
+source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -24,7 +24,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 domain=$(ynh_app_setting_get --app=$app --key=domain)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+db_user=$(ynh_app_setting_get --app=$app --key=db_user) 
 phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
@@ -55,7 +55,7 @@ ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 #=================================================
 ynh_print_info --message="Backing up the PostgreSQL database..."
 
-ynh_psql_dump_db --database="$db_name" > db.sql
+ynh_psql_dump_all_user_dbs --user=$db_user --app=$app
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/backup
+++ b/scripts/backup
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source _common.sh
+source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -55,7 +55,7 @@ ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 #=================================================
 ynh_print_info --message="Backing up the PostgreSQL database..."
 
-ynh_psql_dump_all_user_dbs --user=$db_user --app=$app
+ynh_psql_dump_all_user_dbs --db_user=$db_user --app=$app
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -30,8 +30,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
 # Add settings here as needed by your application
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-db_user=$db_name
+db_user=$(ynh_app_setting_get --app=$app --key=db_user) 
 db_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -164,19 +164,21 @@ You will have to:
 
 Once done, you will be able to log into Noalyss with your credentials:
 -------------------------------------------
-${app^}\'s domain: https://$domain$path_url
-${app^}\'s admin user: $admin
-${app^}\'s admin password: $password
+${app^}'s domain: https://$domain$path_url
+${app^}'s admin user: $admin
+${app^}'s admin password: $password
 -------------------------------------------
 Link to Noalyss' user documentation: https://www.noalyss.eu/?page_id=1031 
+
 
 Please find also for reference the credential for the dedicated PostgreSQL database user:
 -------------------------------------------
 Database's dedicated user: $app
 Database's password: $db_pwd
 -------------------------------------------
+
 If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/noalysse_ynh/issues
-... Or post a message in the forum: https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356"
+Or post a message in the forum: https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356"
 
 ynh_send_readme_to_admin "$message"
 

--- a/scripts/install
+++ b/scripts/install
@@ -171,7 +171,7 @@ Please find also for reference the credential for the dedicated PostgreSQL datab
 Database dedicated user: $app
 Database password: $db_pwd
 
-If you are facing any problem or want to improve this app, please <a href=\"https://github.com/YunoHost-Apps/noalysse_ynh/issues\">open a new issue here</a> or post a message <a href=\"https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356/\">in the forum</a> 
+If you are facing any problem or want to improve this app, please <a href=\"https://github.com/YunoHost-Apps/noalysse_ynh/issues\">open a new issue here</a> or post a message <a href=\"https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356/\">in the forum</a>"
 
 ynh_send_readme_to_admin "$message"
 

--- a/scripts/install
+++ b/scripts/install
@@ -67,8 +67,8 @@ db_user=$(ynh_sanitize_dbid --db_name=$app)
 ynh_app_setting_set --app=$app --key=db_user --value=$db_user
 
 ynh_psql_test_if_first_run 										# Make sure PSQL is installed
-ynh_psql_setup_db --db_user=$db_user --db_name="$db_user_tmp"   # This helper will create db_user, generate db_user_pwd. But it will also create a database Noalyss does not need, hence the "tmp" flag    
-ynh_psql_drop_db "$db_user_tmp"									# Remove the useless database just created with the "tmp" flag.
+ynh_psql_setup_db --db_user=$db_user --db_name="${db_user}_tmp"   # This helper will create db_user, generate db_user_pwd. But it will also create a database Noalyss does not need, hence the "tmp" flag    
+ynh_psql_drop_db "${db_user}_tmp"									# Remove the useless database just created with the "tmp" flag.
 
 # Give permission to db_user to create databases, as with version 9025 at least, standard Noalyss operation (can be tweaked with shared server install process - with potentially less features?) will require to create several databases: one admin database (account_repository), one database per accounting template (two are populated at install by default: mod1, mod2, etc.), one per accounting folder that will be created while using the app, etc.
 if [ -n "$db_user" ]; then 

--- a/scripts/install
+++ b/scripts/install
@@ -158,8 +158,8 @@ message="Noalyss installation is *almost* complete :)
 
 To conclude, please open the admin configuration page of your ${app^} domain: https://$domain$path_url/install.php
 You will have to:
-1. Choose the locale and click on \"Continuer\" (FR) / \"Continue\" (EN).
-2. Scroll the page down and click on the button \"Commencer la mise à jour ou l\'installation ?\" (FR) / \"Start the update or the installation ?\" (EN)
+1. Select the language you want and click on \"Continuer\" (FR) / \"Continue\" (EN).
+2. Scroll the page down and click on the button \"Commencer la mise à jour ou l'installation ?\" (FR) / \"Start the update or the installation ?\" (EN)
 3. Scroll to the bottom of the page and click on the button \"Essai effacement install.php et se connecter à NOALYSS\" (FR) / \"Try erasing install.php and log into NOALYSS\" (EN)
 
 Once done, you will be able to log into Noalyss with your credentials:
@@ -174,7 +174,7 @@ Link to Noalyss' user documentation: https://www.noalyss.eu/?page_id=1031
 Please find also for reference the credential for the dedicated PostgreSQL database user:
 -------------------------------------------
 Database's dedicated user: $app
-Database's password: $db_pwd
+Database's dedicated user's password: $db_pwd
 -------------------------------------------
 
 If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/noalysse_ynh/issues

--- a/scripts/install
+++ b/scripts/install
@@ -123,6 +123,9 @@ ynh_add_config --template="../conf/noalyss.conf" --destination="$final_path/incl
 chmod 650 "$final_path/include/config.inc.php"
 chown $app: "$final_path/include/config.inc.php"
 
+# Make sure to keep an archive of Noalyss' install.php script in case Noalyss' admin user should be updated in the future since the original one will be deleted at the end of install process (cf. instructions in config.inc.php)
+cp "$final_path/html/install.php" "$final_path/html/install.php.archive" 
+
 #=================================================
 # SETUP LOGROTATE
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,6 @@ admin=$YNH_APP_ARG_ADMIN
 password=$YNH_APP_ARG_PASSWORD
 phpversion=$YNH_PHP_VERSION
 timezone="$(cat /etc/timezone)"
-
 app=$YNH_APP_INSTANCE_NAME
 
 #=================================================
@@ -64,14 +63,15 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 #=================================================
 ynh_script_progression --message="Creating a PostgreSQL database..." --weight=2
 
-db_name=$(ynh_sanitize_dbid --db_name=$app)
-db_user=$db_name
-ynh_app_setting_set --app=$app --key=db_name --value=$db_name
-ynh_psql_test_if_first_run
-ynh_psql_setup_db --db_user=$db_user --db_name=$db_name
+db_user=$(ynh_sanitize_dbid --db_name=$app)
+ynh_app_setting_set --app=$app --key=db_user --value=$db_user
 
-#give permission to dedicated role to create databases (required for default install of noalyss)
-if [ -n "$user" ]; then
+ynh_psql_test_if_first_run 										# Make sure PSQL is installed
+ynh_psql_setup_db --db_user=$db_user --db_name="$db_user_tmp"   # This helper will create db_user, generate db_user_pwd. But it will also create a database Noalyss does not need, hence the "tmp" flag    
+ynh_psql_drop_db "$db_user_tmp"									# Remove the useless database just created with the "tmp" flag.
+
+# Give permission to db_user to create databases, as with version 9025 at least, standard Noalyss operation (can be tweaked with shared server install process - with potentially less features?) will require to create several databases: one admin database (account_repository), one database per accounting template (two are populated at install by default: mod1, mod2, etc.), one per accounting folder that will be created while using the app, etc.
+if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -70,6 +70,12 @@ ynh_app_setting_set --app=$app --key=db_name --value=$db_name
 ynh_psql_test_if_first_run
 ynh_psql_setup_db --db_user=$db_user --db_name=$db_name
 
+#give permission to dedicated role to create databases (required for default install of noalyss)
+if [ -n "$user" ]; then
+	sql="ALTER USER $db_user CREATEDB"
+	ynh_psql_execute_as_root --sql="$sql"
+fi
+
 #=================================================
 # CREATE DEDICATED USER
 #=================================================
@@ -117,8 +123,6 @@ ynh_add_config --template="../conf/noalyss.conf" --destination="$final_path/incl
 chmod 650 "$final_path/include/config.inc.php"
 chown $app: "$final_path/include/config.inc.php"
 
-ynh_secure_remove --file="/var/www/noalyss/html/install.php"
-
 #=================================================
 # SETUP LOGROTATE
 #=================================================
@@ -148,20 +152,26 @@ ynh_systemd_action --service_name=nginx --action=reload
 #=================================================
 # SEND A README FOR THE ADMIN
 #=================================================
-ynh_script_progression --message="Sending a readme for the admin..."
+ynh_script_progression --message="Sending a readme to the admin email address. Please check it to complete the installation process."
 
-message="Noalyss was successfully installed :)
+message="Noalyss installation is almost finished :)
 
-Please open your $app domain: https://$domain$path_url
+Please open the admin configuration page of your $app domain: https://$domain$path_url/install.php
+From here, complete the registration process by:
+1. Choosing language and clicking on \"Continuer\" (FR) / \"Continue\" (EN).
+2. Scroll the page down and click on the button \"Commencer la mise à jour ou l\'installation ?\" (FR) / \"Start the update or the installation ?\" (EN)
+3. Scroll to the bottom of the page and click on the button \"Essai effacement install.php et se connecter à NOALYSS\" (FR) / \"Try erasing install.php and log into NOALYSS\" (EN)
 
-Complete the registration process from the setup page displayed.
-Details for PostgreSQL database to be enterted while registration process:
+Once donce, you will be able to log into Noalyss with your credentials:
+$app domain: https://$domain$path_url
+$app admin user: $admin
+$app admin password: $password
 
-Database login:    $app
-Database name:     $app
+Please find also for reference the credential for the dedicated PostgreSQL database user:
+Database dedicated user: $app
 Database password: $db_pwd
 
-If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/noalysse_ynh/issues"
+If you are facing any problem or want to improve this app, please <a href=\"https://github.com/YunoHost-Apps/noalysse_ynh/issues\">open a new issue here</a> or post a message <a href=\"https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356/\">in the forum</a> 
 
 ynh_send_readme_to_admin "$message"
 

--- a/scripts/install
+++ b/scripts/install
@@ -154,24 +154,29 @@ ynh_systemd_action --service_name=nginx --action=reload
 #=================================================
 ynh_script_progression --message="Sending a readme to the admin email address. Please check it to complete the installation process."
 
-message="Noalyss installation is almost finished :)
+message="Noalyss installation is *almost* complete :)
 
-Please open the admin configuration page of your $app domain: https://$domain$path_url/install.php
-From here, complete the registration process by:
-1. Choosing language and clicking on \"Continuer\" (FR) / \"Continue\" (EN).
+To conclude, please open the admin configuration page of your ${app^} domain: https://$domain$path_url/install.php
+You will have to:
+1. Choose the locale and click on \"Continuer\" (FR) / \"Continue\" (EN).
 2. Scroll the page down and click on the button \"Commencer la mise à jour ou l\'installation ?\" (FR) / \"Start the update or the installation ?\" (EN)
 3. Scroll to the bottom of the page and click on the button \"Essai effacement install.php et se connecter à NOALYSS\" (FR) / \"Try erasing install.php and log into NOALYSS\" (EN)
 
-Once donce, you will be able to log into Noalyss with your credentials:
-$app domain: https://$domain$path_url
-$app admin user: $admin
-$app admin password: $password
+Once done, you will be able to log into Noalyss with your credentials:
+-------------------------------------------
+${app^}\'s domain: https://$domain$path_url
+${app^}\'s admin user: $admin
+${app^}\'s admin password: $password
+-------------------------------------------
+Link to Noalyss' user documentation: https://www.noalyss.eu/?page_id=1031 
 
 Please find also for reference the credential for the dedicated PostgreSQL database user:
-Database dedicated user: $app
-Database password: $db_pwd
-
-If you are facing any problem or want to improve this app, please <a href=\"https://github.com/YunoHost-Apps/noalysse_ynh/issues\">open a new issue here</a> or post a message <a href=\"https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356/\">in the forum</a>"
+-------------------------------------------
+Database's dedicated user: $app
+Database's password: $db_pwd
+-------------------------------------------
+If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/noalysse_ynh/issues
+... Or post a message in the forum: https://forum.yunohost.org/t/noalyss-beligum-and-french-accounting/7356"
 
 ynh_send_readme_to_admin "$message"
 

--- a/scripts/install
+++ b/scripts/install
@@ -123,7 +123,7 @@ ynh_add_config --template="../conf/noalyss.conf" --destination="$final_path/incl
 chmod 650 "$final_path/include/config.inc.php"
 chown $app: "$final_path/include/config.inc.php"
 
-# Make sure to keep an archive of Noalyss' install.php script in case Noalyss' admin user should be updated in the future since the original one will be deleted at the end of install process (cf. instructions in config.inc.php)
+# Keep an archive of Noalyss' install.php script for it to be reachable by YNH restore script since the original file is deleted at the end of the install process (this archive is currently left unused, but it could be useful for future potential implementation such as scripting the admin admin user change - cf. annotations in Noalyss' /inlude/config.inc.php for use case).
 cp "$final_path/html/install.php" "$final_path/html/install.php.archive" 
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -22,12 +22,35 @@ db_user=$db_name
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
 #=================================================
-# REMOVE THE POSTGRESQL DATABASE
+# REMOVE THE POSTGRESQL DATABASE(S) & ROLE
 #=================================================
-ynh_script_progression --message="Removing the PostgreSQL database"
+ynh_script_progression --message="Removing all associated PostgreSQL database(s) and role"
 
-# Remove a database if it exists, along with the associated user
-ynh_psql_remove_db --db_user=$db_user --db_name=$db_name
+# Remove all existing databases associated with the app's dedicated user a database if it exists
+sql="COPY (SELECT datname FROM pg_database JOIN pg_authid ON pg_database.datdba = pg_authid.oid WHERE rolname = '${db_user}') TO STDOUT"
+dbs_to_drop=ynh_psql_execute_as_root --sql="$sql" #Fetch database(s) associated to role $db_user
+
+if [[ -n "$dbs_to_drop" ]]; then # Check that the list of database(s) is not empty 
+	for $db_name in $dbs_to_drop   # Iterate through the list of database(s) to remove
+	do
+		if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
+			ynh_psql_drop_db $db_name                         # Remove the database
+			ynh_print_info --message="Removed database $db_name associated to role $db_user"
+		else
+			ynh_print_warn --message="Database $db_name not found"
+		fi
+	done
+else 
+	ynh_print_warn --message="No associated database to role $db_user was found"
+fi
+
+# Remove dedicated PostgreSQL role
+if ynh_psql_user_exists --user=$db_user; then
+    ynh_psql_drop_user $db_user
+	ynh_print_info --message="Removed PostgreSQL role $db_user"
+else
+    ynh_print_warn --message="User $db_user not found"
+fi 
 
 #=================================================
 # REMOVE APP MAIN DIR

--- a/scripts/remove
+++ b/scripts/remove
@@ -17,8 +17,7 @@ ynh_script_progression --message="Loading installation settings..."
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-db_user=$db_name
+db_user=$(ynh_app_setting_get --app=$app --key=db_user) 
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
 #=================================================
@@ -27,22 +26,7 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 ynh_script_progression --message="Removing all associated PostgreSQL database(s) and role"
 
 # Remove all existing databases associated with the app's dedicated user a database if it exists
-sql="COPY (SELECT datname FROM pg_database JOIN pg_authid ON pg_database.datdba = pg_authid.oid WHERE rolname = '${db_user}') TO STDOUT"
-dbs_to_drop=ynh_psql_execute_as_root --sql="$sql" #Fetch database(s) associated to role $db_user
-
-if [[ -n "$dbs_to_drop" ]]; then # Check that the list of database(s) is not empty 
-	for $db_name in $dbs_to_drop   # Iterate through the list of database(s) to remove
-	do
-		if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
-			ynh_psql_drop_db $db_name                         # Remove the database
-			ynh_print_info --message="Removed database $db_name associated to role $db_user"
-		else
-			ynh_print_warn --message="Database $db_name not found"
-		fi
-	done
-else 
-	ynh_print_warn --message="No associated database to role $db_user was found"
-fi
+ynh_psql_remove_all_user_dbs --user=$db_user; 
 
 # Remove dedicated PostgreSQL role
 if ynh_psql_user_exists --user=$db_user; then

--- a/scripts/remove
+++ b/scripts/remove
@@ -26,7 +26,7 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 ynh_script_progression --message="Removing all associated PostgreSQL database(s) and role"
 
 # Remove all existing databases associated with the app's dedicated user a database if it exists
-ynh_psql_remove_all_user_dbs --user=$db_user; 
+ynh_psql_remove_all_user_dbs --db_user=$db_user; 
 
 # Remove dedicated PostgreSQL role
 if ynh_psql_user_exists --user=$db_user; then

--- a/scripts/restore
+++ b/scripts/restore
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source _common.sh
+source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,7 +91,7 @@ ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
-	sql= "ALTER USER noalyss WITH PASSWORD '${db_user_pwd}'" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+	sql= "ALTER USER noalyss WITH PASSWORD \"$db_user_pwd\"" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
 	ynh_psql_execute_as_root --sql="$sql"
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,7 +91,7 @@ ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
-	sql= "ALTER USER noalyss WITH PASSWORD '$db_user_pwd'" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+	sql="ALTER USER noalyss WITH PASSWORD '$db_user_pwd'" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
 	ynh_psql_execute_as_root --sql="$sql"
 fi
 	

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,7 +91,7 @@ ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
-	sql= "ALTER USER noalyss WITH PASSWORD ${db_user_pwd}" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+	sql= "ALTER USER noalyss WITH PASSWORD '${db_user_pwd}'" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
 	ynh_psql_execute_as_root --sql="$sql"
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,8 +91,8 @@ ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
-	psql -c "ALTER USER noalyss WITH PASSWORD $db_user_pwd" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
-
+	sql= "ALTER USER noalyss WITH PASSWORD $db_user_pwd" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+	ynh_psql_execute_as_root --sql="$sql"
 fi
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,7 +91,7 @@ ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
-	sql= "ALTER USER noalyss WITH PASSWORD $db_user_pwd" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+	sql= "ALTER USER noalyss WITH PASSWORD ${db_user_pwd}" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
 	ynh_psql_execute_as_root --sql="$sql"
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -85,13 +85,11 @@ ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 #=================================================
 ynh_script_progression --message="Restoring the PostgreSQL database..."
 
-ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
+ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=$db_user_pwd
 
 # Give permission to db_user to create databases, as with version 9025 at least, standard Noalyss operation (can be tweaked with shared server install process - with potentially less features?) will require to create several databases: one admin database (account_repository), one database per accounting template (two are populated at install by default: mod1, mod2, etc.), one per accounting folder that will be created while using the app, etc.
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
-	ynh_psql_execute_as_root --sql="$sql"
-	sql="ALTER USER noalyss WITH PASSWORD '$db_user_pwd'" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
 	ynh_psql_execute_as_root --sql="$sql"
 fi
 	

--- a/scripts/restore
+++ b/scripts/restore
@@ -85,7 +85,7 @@ ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 #=================================================
 ynh_script_progression --message="Restoring the PostgreSQL database..."
 
-ynh_psql_restore_all_app_dbs_dumps --db_user=db_user --db_user_pwd=db_user_pwd
+ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -87,6 +87,14 @@ ynh_script_progression --message="Restoring the PostgreSQL database..."
 
 ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 
+# Give permission to db_user to create databases, as with version 9025 at least, standard Noalyss operation (can be tweaked with shared server install process - with potentially less features?) will require to create several databases: one admin database (account_repository), one database per accounting template (two are populated at install by default: mod1, mod2, etc.), one per accounting folder that will be created while using the app, etc.
+if [ -n "$db_user" ]; then 
+	sql="ALTER USER $db_user CREATEDB"
+	ynh_psql_execute_as_root --sql="$sql"
+	psql -c "ALTER USER noalyss WITH PASSWORD $db_user_pwd" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+
+fi
+
 #=================================================
 # GENERIC FINALIZATION
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source ../settings/scripts/_common.sh
+source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -26,9 +26,8 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-db_user=$db_name
-db_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
+db_user=$(ynh_app_setting_get --app=$app --key=db_user) 
+db_user_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
@@ -86,9 +85,7 @@ ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 #=================================================
 ynh_script_progression --message="Restoring the PostgreSQL database..."
 
-ynh_psql_test_if_first_run
-ynh_psql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
-ynh_psql_execute_file_as_root --file="./db.sql" --database=$db_name
+ynh_psql_restore_all_app_dbs_dumps --db_user=db_user --db_user_pwd=db_user_pwd
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,10 +91,10 @@ ynh_psql_restore_all_app_dbs_dumps --db_user=$db_user --db_user_pwd=db_user_pwd
 if [ -n "$db_user" ]; then 
 	sql="ALTER USER $db_user CREATEDB"
 	ynh_psql_execute_as_root --sql="$sql"
-	sql= "ALTER USER noalyss WITH PASSWORD \"$db_user_pwd\"" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
+	sql= "ALTER USER noalyss WITH PASSWORD '$db_user_pwd'" #Workaround to restore the backed up password, since as of 23 January 2023, there seems to be a bug in ynh_psql_setup_db() helper (YNH Core) forcing password reset.
 	ynh_psql_execute_as_root --sql="$sql"
 fi
-
+	
 #=================================================
 # GENERIC FINALIZATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -19,9 +19,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-db_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
-db_user=$db_name
+db_user=$(ynh_app_setting_get --app=$app --key=db_user) 
 phpversion=$(ynh_app_setting_get --app="$app" --key=phpversion)
 
 #=================================================
@@ -49,10 +47,10 @@ ynh_abort_if_errors
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 
-# If db_name doesn't exist, create it
-if [ -z "$db_name" ]; then
-	db_name=$(ynh_sanitize_dbid --db_name=$app)
-	ynh_app_setting_set --app=$app --key=db_name --value=$db_name
+# If db_user doesn't exist, create it
+if [ -z "$db_user" ]; then
+	db_user=$(ynh_sanitize_dbid --db_name=$app)
+	ynh_app_setting_set --app=$app --key=db_user --value=$db_user
 fi
 
 # If final_path doesn't exist, create it


### PR DESCRIPTION
## Problem

The app does not install successfully because:
- the app PHP script which set up databases ("install.php") is deleted in this package's install script. Thus it cannot be run.
- the PSQL user created by YNH install script is not allowed to create databases, thus running install.php script cannot set up the required databases (Thanks to Supermanu [for reporting this](https://github.com/YunoHost-Apps/noalyss_ynh/issues/24#issuecomment-1059386714)).
- this app requires to set up multiple PSQL databases: one for the app admin ("account_repository") + one for each of the accounting ruleset (2 by default : "mod1" & "mod2") +  one for each new accounting project. This prerequisite is not handled by the current package.
 
## Solution

- Keep app's "install.php" script (and archive if needed for future use). Dumps of the initial databases could have been used instead so that no external script to YNH would be needed, but it was thought that keep using "install.php" script to set up the initial databases would make the maintenance of the YNH package easier in case Noalyss' publisher updates the databases structure in the future.
- Grant CREATE_DB privilege to the app's dedicated PSQL user. 
- Create additional helpers in _common.sh to handle multiple databases belonging to the same PSQL user.

In addition, several other minor improvements were brought to the package such as modification of the email sent to the admin after install, etc. 
 
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
